### PR TITLE
Prevent booking service from possible database connection overload

### DIFF
--- a/ms-booking/src/main/java/com/tutorials/msbooking/controller/BookingController.java
+++ b/ms-booking/src/main/java/com/tutorials/msbooking/controller/BookingController.java
@@ -93,10 +93,10 @@ public class BookingController {
     }
 
     @DeleteMapping
-    public ResponseEntity<List<BookingRsModel>> deleteBooking(@RequestParam(name = "flight-id") UUID flightId) {
+    public ResponseEntity<List<BookingRsModel>> deleteBookings(@RequestParam(name = "flight-id") UUID flightId) {
         log.info(REQUEST_LOG_FORMAT, BOOKINGS_URL + "?flight-id=" + flightId, null);
 
-        var response = bookingService.deleteBooking(flightId);
+        var response = bookingService.deleteBatchBooking(flightId);
 
         log.info(RESPONSE_LOG_FORMAT, BOOKINGS_URL + "?flight-id=" + flightId, response);
         return ResponseEntity.ok().body(response);

--- a/ms-booking/src/main/java/com/tutorials/msbooking/repository/BookingRepository.java
+++ b/ms-booking/src/main/java/com/tutorials/msbooking/repository/BookingRepository.java
@@ -7,6 +7,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface BookingRepository extends JpaRepository<Booking, Long> {
     Optional<Booking> findByExternalIdAndUserAndActiveTrue(UUID id, User user);
@@ -28,4 +30,8 @@ public interface BookingRepository extends JpaRepository<Booking, Long> {
     default Optional<Booking> findByIdAndUser(UUID id, User user) {
         return findByExternalIdAndUserAndActiveTrue(id, user);
     }
+
+    @Modifying
+    @Query(" UPDATE Booking b SET b.active = false WHERE b.flight.id = :flightId")
+    void updateBookingActiveFalse(UUID flightId);
 }

--- a/ms-booking/src/main/java/com/tutorials/msbooking/service/BookingService.java
+++ b/ms-booking/src/main/java/com/tutorials/msbooking/service/BookingService.java
@@ -16,5 +16,5 @@ public interface BookingService {
 
     BookingRsModel deleteBooking(UUID id, String username);
 
-    List<BookingRsModel> deleteBooking(UUID flightId);
+    List<BookingRsModel> deleteBatchBooking(UUID flightId);
 }

--- a/ms-booking/src/main/java/com/tutorials/msbooking/service/impl/BookingServiceImpl.java
+++ b/ms-booking/src/main/java/com/tutorials/msbooking/service/impl/BookingServiceImpl.java
@@ -1,7 +1,5 @@
 package com.tutorials.msbooking.service.impl;
 
-import static com.tutorials.msbooking.mapper.BookingMapper.BOOKING_MAPPER_INSTANCE;
-
 import com.tutorials.msbooking.entity.Booking;
 import com.tutorials.msbooking.entity.User;
 import com.tutorials.msbooking.exception.BookingException;
@@ -11,12 +9,13 @@ import com.tutorials.msbooking.repository.BookingRepository;
 import com.tutorials.msbooking.service.BookingService;
 import com.tutorials.msbooking.service.FlightService;
 import com.tutorials.msbooking.service.UserService;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
+
+import static com.tutorials.msbooking.mapper.BookingMapper.BOOKING_MAPPER_INSTANCE;
 
 @Service
 @AllArgsConstructor
@@ -54,9 +53,7 @@ public class BookingServiceImpl implements BookingService {
 
     @Override
     public List<BookingRsModel> getAllBookings(String username) {
-        var bookings = bookingRepo.findAllByUserAndActiveTrue(userService.userByUsername(username));
-
-        return bookings
+        return bookingRepo.findAllByUserAndActiveTrue(userService.userByUsername(username))
                 .stream()
                 .map(BOOKING_MAPPER_INSTANCE::mapEntityToResponse)
                 .toList();
@@ -79,19 +76,11 @@ public class BookingServiceImpl implements BookingService {
     }
 
     @Override
-    public List<BookingRsModel> deleteBooking(UUID flightId) {
-        var bookings = bookingRepo.findAllByFlightId(flightId);
-
-        var response = new ArrayList<BookingRsModel>();
-
-        bookings.forEach(booking -> {
-            booking.setActive(false);
-            bookingRepo.save(booking);
-            log.info("Booking active is set to false: {}", booking);
-            response.add(BOOKING_MAPPER_INSTANCE.mapEntityToResponse(booking));
-        });
-
-        return response;
+    public List<BookingRsModel> deleteBatchBooking(UUID flightId) {
+        bookingRepo.updateBookingActiveFalse(flightId);
+        return bookingRepo.findAllByFlightId(flightId).stream().
+                map(BOOKING_MAPPER_INSTANCE::mapEntityToResponse)
+                .toList();
     }
 
     private Booking bookingByIdAndUser(UUID id, User user) {

--- a/ms-booking/src/main/java/com/tutorials/msbooking/util/Constants.java
+++ b/ms-booking/src/main/java/com/tutorials/msbooking/util/Constants.java
@@ -2,7 +2,9 @@ package com.tutorials.msbooking.util;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import lombok.experimental.UtilityClass;
 
+@UtilityClass
 @NoArgsConstructor(access = AccessLevel.NONE)
 public final class Constants {
     public static final String REQUEST_LOG_FORMAT = "Request data: [URL: {}, payload: {}]";


### PR DESCRIPTION
Batch deactivation was under the risk of making too many database connection/ keeping the connection open for too long. Handling the batch process in the SQL query should be quicker and more efficient unless there is a seperate business logic.

minor renaming for distinction between single and batch deactivation of bookings.